### PR TITLE
replace local_file with local_sensitive_file

### DIFF
--- a/modules/ssh-key/main.tf
+++ b/modules/ssh-key/main.tf
@@ -6,9 +6,9 @@ resource "tls_private_key" "key" {
   algorithm = "RSA"
 }
 
-resource "local_file" "private_key" {
+resource "local_sensitive_file" "private_key" {
   filename          = "${var.namespace}-key.pem"
-  sensitive_content = tls_private_key.key.private_key_pem
+  content           = tls_private_key.key.private_key_pem
   file_permission   = "0400"
 }
 


### PR DESCRIPTION
It's should be replaced by local_file to local_sensitive_file. because local_file was defined as deprecated.